### PR TITLE
allow multiple level json key to be used

### DIFF
--- a/bin/check-http-json.rb
+++ b/bin/check-http-json.rb
@@ -36,6 +36,9 @@ require 'json'
 require 'net/http'
 require 'net/https'
 
+#
+# Check JSON
+#
 class CheckJson < Sensu::Plugin::Check::CLI
   option :url, short: '-u URL'
   option :host, short: '-h HOST'

--- a/bin/check-http.rb
+++ b/bin/check-http.rb
@@ -35,6 +35,9 @@ require 'sensu-plugin/check/cli'
 require 'net/http'
 require 'net/https'
 
+#
+# Check HTTP
+#
 class CheckHTTP < Sensu::Plugin::Check::CLI
   option :ua,
          short: '-x USER-AGENT',

--- a/bin/check-https-cert.rb
+++ b/bin/check-https-cert.rb
@@ -31,6 +31,9 @@ require 'rubygems' if RUBY_VERSION < '1.9.0'
 require 'sensu-plugin/check/cli'
 require 'net/https'
 
+#
+# Check HTTP
+#
 class CheckHTTP < Sensu::Plugin::Check::CLI
   option :url,
          short: '-u URL',

--- a/bin/metrics-curl.rb
+++ b/bin/metrics-curl.rb
@@ -33,6 +33,9 @@ require 'rubygems' if RUBY_VERSION < '1.9.0'
 require 'socket'
 require 'sensu-plugin/metric/cli'
 
+#
+# Curl Metrics
+#
 class CurlMetrics < Sensu::Plugin::Metric::CLI::Graphite
   option :url,
          short: '-u URL',


### PR DESCRIPTION
This allows foo.bar.baz to  be used as a key. It also allows keys with periods in through escaping, e.g: foo.bar\\.bar.baux which would look up: foo, bar.baz, baux.