### PR TITLE
Add ability to print whole response in check-http

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,8 @@
 mkmf.log
 .vagrant/*
 .DS_Store
-.idea/*
 *.gem
+
+#Intellij files
+*.iml
+*.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,14 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
-## Unreleased][unreleased]
+## 0.1.0 - 2015-06-18
+- A new non-breaking feature - the ability to print the whole response from the http call done in the check-http.rb check to the sensu alert. This can be done by specifying the ```-w``` or ```--whole-response``` parameters.
+- Gitignore was updated with more files from Intellij IDEA
+
+## 0.0.2 - 2015-06-03
+- Fix the build
 
 ## 0.0.1 - 2015-05-21
 
 ### Added
-- initial release
+- Initial release

--- a/bin/check-http.rb
+++ b/bin/check-http.rb
@@ -131,6 +131,13 @@ class CheckHttp < Sensu::Plugin::Check::CLI
          long: '--redirect-to URL',
          description: 'Redirect to another page'
 
+  option :whole_response,
+         short: '-w',
+         long: '--whole-response',
+         boolean: true,
+         default: false,
+         description: 'Print whole output when check fails'
+
   option :response_bytes,
          short: '-b BYTES',
          long: '--response-bytes BYTES',
@@ -230,10 +237,14 @@ class CheckHttp < Sensu::Plugin::Check::CLI
     end
     res = http.request(req)
 
-    if config[:response_bytes]
-      body = "\n" + res.body[0..config[:response_bytes]]
+    if config[:whole_response]
+      body = "\n" + res.body
     else
-      body = ''
+      if config[:response_bytes]
+        body = "\n" + res.body[0..config[:response_bytes]]
+      else
+        body = ''
+      end
     end
 
     if config[:require_bytes] && res.body.length != config[:require_bytes]


### PR DESCRIPTION
This PR is a proposition of two changes:
- Add the -w or --whole-response to the check-http.rb check. When the check is failing, the whole message received will be displayed in the message
- Add the intellij project files to ignored in gitignore.

This is the PR requested by @mattyjones in this PR on the (soon deprecated) [sensu-community-plugins](https://github.com/sensu/sensu-community-plugins): https://github.com/sensu/sensu-community-plugins/pull/1195