### PR TITLE
Update check-http.rb to fix connection timeout bug

### DIFF
--- a/bin/check-http.rb
+++ b/bin/check-http.rb
@@ -201,6 +201,9 @@ class CheckHttp < Sensu::Plugin::Check::CLI
     else
       http = Net::HTTP.new(config[:host], config[:port])
     end
+    http.read_timeout = config[:timeout]
+    http.open_timeout = config[:timeout]
+    http.ssl_timeout = config[:timeout]
 
     warn_cert_expire = nil
     if config[:ssl]


### PR DESCRIPTION
Net:HTTP has an implicit timeout value of 60 seconds for most things. If you run this script with a --timeout greater than 60 seconds, Net::HTTP will act as if the timeout was still 60 seconds at the connection level.

This patch tells Net::HTTP to adjust its timeout so that it's never less than the script --timeout value.