### PR TITLE
Verify proxy url is valid

### DIFF
--- a/bin/check-http.rb
+++ b/bin/check-http.rb
@@ -197,6 +197,9 @@ class CheckHttp < Sensu::Plugin::Check::CLI
       http = Net::HTTP.new(config[:host], config[:port], nil, nil)
     elsif config[:proxy_url]
       proxy_uri = URI.parse(config[:proxy_url])
+      if proxy_uri.host.nil?
+        unknown 'Invalid proxy url specified'
+      end
       http = Net::HTTP.new(config[:host], config[:port], proxy_uri.host, proxy_uri.port)
     else
       http = Net::HTTP.new(config[:host], config[:port])


### PR DESCRIPTION
When using the --proxy-url option in check-http, if the URL is malformed, the option is basically ignored. I ran into a situation where a check was configured to verify a proxy server was working, but the url was mistyped, effectively making the check useless since it bypassed using the proxy.

I added quick little check in the code to make sure that the proxy url could be parsed and if not warn the user.