### PR TITLE
Error message is outputted when a connection cannot be established

### DIFF
--- a/bin/check-https-cert.rb
+++ b/bin/check-https-cert.rb
@@ -74,7 +74,6 @@ class CheckHttpCert < Sensu::Plugin::Check::CLI
     end
 
   rescue
-    message "Could not connect to #{config[:url]}"
-    exit 1
+    critical "Could not connect to #{config[:url]}"
   end
 end


### PR DESCRIPTION
When I try to use the ```check-https-cert.rb``` check against a host for which a connection cannot be established, no error message is outputted (although there is an exit code of 1).

```
# /usr/local/bin/check-https-cert.rb -u https://anthcourtney.com
# echo $?
1
```

This results in the check appearing in a warning state within sensu, without any output correlated to the check. 

Like the other http checks, I believe that there should be output in the event of failure.

```
# /usr/local/bin/check-https-cert.rb -u https://anthcourtney.com
CheckHttpCert CRITICAL: Could not connect to https://anthcourtney.com
# echo $?
2
```

You could argue that it should only be WARNING instead of CRITICAL.