### PR TITLE
Allow insecure option for checking wildcard certificates

### DIFF
--- a/bin/check-https-cert.rb
+++ b/bin/check-https-cert.rb
@@ -84,7 +84,6 @@ class CheckHttpCert < Sensu::Plugin::Check::CLI
     end
 
   rescue
-    message "Could not connect to #{config[:url]}"
-    exit 1
+    critical "Could not connect to #{config[:url]}"
   end
 end

--- a/bin/check-https-cert.rb
+++ b/bin/check-https-cert.rb
@@ -74,7 +74,6 @@ class CheckHttpCert < Sensu::Plugin::Check::CLI
     end
 
   rescue
-    message "Could not connect to #{config[:url]}"
-    exit 1
+    critical "Could not connect to #{config[:url]}"
   end
 end


### PR DESCRIPTION
When I try to check an ssl certificate for blah.mydomain.com, and that ssl certificate is a wildcard certificate (i.e. *.mydomain.com), the ```check-https-cert.rb``` check fails (presumably because of the domain mismatch).

Adding support for insecure mode (a'la other http checks) allows the verification of the certificate to occur, irrespective of whether it is a wildcard certificate (and therefore doesn't exactly match the requested url.