### PR TITLE
Fixes SSL verification error raised errornously when using -e flag

### DIFF
--- a/bin/check-http.rb
+++ b/bin/check-http.rb
@@ -223,6 +223,8 @@ class CheckHttp < Sensu::Plugin::Check::CLI
           if ssl_context.current_cert.not_after <= expire_warn_date
             warn_cert_expire = ssl_context.current_cert.not_after
           end
+
+          _preverify_ok
         end
       end
     end

--- a/bin/check-http.rb
+++ b/bin/check-http.rb
@@ -219,12 +219,12 @@ class CheckHttp < Sensu::Plugin::Check::CLI
       unless config[:expiry].nil?
         expire_warn_date = Time.now + (config[:expiry] * 60 * 60 * 24)
         # We can't raise inside the callback, have to check when we finish.
-        http.verify_callback = proc do |_preverify_ok, ssl_context|
+        http.verify_callback = proc do |preverify_ok, ssl_context|
           if ssl_context.current_cert.not_after <= expire_warn_date
             warn_cert_expire = ssl_context.current_cert.not_after
           end
 
-          _preverify_ok
+          preverify_ok
         end
       end
     end


### PR DESCRIPTION
E.g. Before:
Google should work, cacert should error

$ /opt/sensu/embedded/bin/ruby check-http.rb -u "https://www.google.com/" -e20
CheckHttp CRITICAL: Request error: SSL_connect returned=1 errno=0 state=error: certificate verify failed

$ /opt/sensu/embedded/bin/ruby check-http.rb -u "https://www.cacert.org/" -e20
CheckHttp CRITICAL: Request error: SSL_connect returned=1 errno=0 state=error: certificate verify failed

After:
Google now works
$ /opt/sensu/embedded/bin/ruby check-http.rb -u "https://www.google.com/" -e20
CheckHttp WARNING: 302

Cacert still fails correctly
$ /opt/sensu/embedded/bin/ruby check-http.rb -u "https://www.cacert.org/" -e20
CheckHttp CRITICAL: Request error: SSL_connect returned=1 errno=0 state=error: certificate verify failed