### PR TITLE
Fix spacing issue in headers + add POST support to check-http.rb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ mkmf.log
 .vagrant/*
 .DS_Store
 *.gem
+.kitchen/
 
 #Intellij files
 *.iml

--- a/.kitchen.travis.yml
+++ b/.kitchen.travis.yml
@@ -1,0 +1,2 @@
+driver:
+  name: localhost

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,0 +1,17 @@
+---
+driver:
+  name: vagrant
+
+provisioner:
+  name: shell
+  data_path: .
+  script: test/fixtures/bootstrap.sh
+
+verifier:
+  ruby_bindir: /opt/sensu/embedded/bin
+
+platforms:
+  - name: ubuntu-14.04
+
+suites:
+  - name: default

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: ruby
+sudo: required
+dist: trusty
 cache:
 - bundler
 install:
@@ -15,9 +17,10 @@ notifications:
     on_success: change
     on_failure: always
 script:
-- bundle exec rake default
-- gem build sensu-plugins-http.gemspec
-- gem install sensu-plugins-http-*.gem
+  - bundle exec rake default
+  - bundle exec kitchen test
+  - gem build sensu-plugins-http.gemspec
+  - gem install sensu-plugins-http-*.gem
 deploy:
   provider: rubygems
   api_key:
@@ -31,3 +34,6 @@ deploy:
     rvm: 2.1
     rvm: 2.2
     repo: sensu-plugins/sensu-plugins-http
+
+env:
+  - KITCHEN_LOCAL_YAML=.kitchen.travis.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+- Support comma+space-separated headers in check-http.rb
 
 ## [0.2.1] - 2015-12-14
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ## [Unreleased]
 - Support comma+space-separated headers in check-http.rb
 - Support POST requests in check-http.rb
+- Add a Test Kitchen config and BATS tests for CI
 
 ## [0.2.1] - 2015-12-14
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased]
 - Support comma+space-separated headers in check-http.rb
+- Support POST requests in check-http.rb
 
 ## [0.2.1] - 2015-12-14
 ### Added

--- a/bin/check-http.rb
+++ b/bin/check-http.rb
@@ -240,7 +240,7 @@ class CheckHttp < Sensu::Plugin::Check::CLI
     if config[:header]
       config[:header].split(',').each do |header|
         h, v = header.split(':', 2)
-        req[h] = v.strip
+        req[h.strip] = v.strip
       end
     end
     res = http.request(req)

--- a/bin/check-http.rb
+++ b/bin/check-http.rb
@@ -65,10 +65,22 @@ class CheckHttp < Sensu::Plugin::Check::CLI
          long: '--request-uri PATH',
          description: 'Specify a uri path'
 
+  option :method,
+         short: '-m GET|POST',
+         long: '--method GET|POST',
+         description: 'Specify a GET or POST operation; defaults to GET',
+         in: %w(GET POST),
+         default: 'GET'
+
   option :header,
          short: '-H HEADER',
          long: '--header HEADER',
-         description: 'Check for a HEADER'
+         description: 'Send one or more comma-separated headers with the request'
+
+  option :body,
+         short: '-b BODY',
+         long: '--body BODY',
+         description: 'Send a body string with the request'
 
   option :ssl,
          short: '-s',
@@ -232,7 +244,12 @@ class CheckHttp < Sensu::Plugin::Check::CLI
       end
     end
 
-    req = Net::HTTP::Get.new(config[:request_uri], 'User-Agent' => config[:ua])
+    req = case config[:method]
+          when 'GET'
+            Net::HTTP::Get.new(config[:request_uri], 'User-Agent' => config[:ua])
+          when 'POST'
+            Net::HTTP::Post.new(config[:request_uri], 'User-Agent' => config[:ua])
+          end
 
     if !config[:user].nil? && !config[:password].nil?
       req.basic_auth config[:user], config[:password]
@@ -243,6 +260,8 @@ class CheckHttp < Sensu::Plugin::Check::CLI
         req[h.strip] = v.strip
       end
     end
+    req.body = config[:body] if config[:body]
+
     res = http.request(req)
 
     body = if config[:whole_response]

--- a/sensu-plugins-http.gemspec
+++ b/sensu-plugins-http.gemspec
@@ -51,4 +51,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec',                     '~> 3.1'
   s.add_development_dependency 'rubocop',                   '~> 0.37'
   s.add_development_dependency 'yard',                      '~> 0.8'
+  s.add_development_dependency 'test-kitchen',              '~> 1.6'
+  s.add_development_dependency 'kitchen-vagrant',           '~> 0.19'
+  s.add_development_dependency 'kitchen-localhost',         '~> 0.3'
+  s.add_development_dependency 'net-ssh',                   '~> 2.9'
 end

--- a/test/fixtures/bootstrap.sh
+++ b/test/fixtures/bootstrap.sh
@@ -1,0 +1,61 @@
+#!/bin/sh
+#
+# Set up a super simple web server and make it accept GET and POST requests
+# for Sensu plugin testing.
+#
+
+DATA_DIR=/tmp/kitchen/data
+SENSU_DIR=/opt/sensu
+GEM=$SENSU_DIR/embedded/bin/gem
+RUBY=$SENSU_DIR/embedded/bin/ruby
+
+if [ ! -d $SENSU_DIR ]; then
+  wget -q http://repositories.sensuapp.org/apt/pubkey.gpg -O- | sudo apt-key add -
+  echo "deb http://repositories.sensuapp.org/apt sensu main" | sudo tee /etc/apt/sources.list.d/sensu.list
+  sudo apt-get update
+  sudo apt-get install -y git vim nginx sensu
+  sudo service nginx status || sudo service nginx start
+  sudo rm /etc/nginx/sites-enabled/default
+  echo "
+    server {
+      listen 80;
+    
+      location /okay {
+        limit_except GET {
+          deny all;
+        }
+        return 200;
+      }
+    
+      location /notthere {
+        limit_except GET {
+          deny all;
+        }
+        return 404;
+      }
+    
+      location /ohno {
+        limit_except GET {
+          deny all;
+        }
+        return 500;
+      }
+
+      location /gooverthere {
+         limit_except GET {
+           deny all;
+         }
+         return 301;
+      }
+    
+      location /postthingshere {
+        return 200;
+      }
+    }
+  " | sudo tee /etc/nginx/sites-enabled/sensu-plugins-http.conf
+  sudo service nginx restart
+fi
+
+cd $DATA_DIR
+SIGN_GEM=false $GEM build sensu-plugins-http.gemspec
+sudo sensu-install -p sensu-plugins-http-*.gem

--- a/test/integration/default/bats/check-http.bats
+++ b/test/integration/default/bats/check-http.bats
@@ -1,0 +1,46 @@
+#!/usr/bin/env bats
+
+setup() {
+  export CHECK="sudo -u sensu /opt/sensu/embedded/bin/check-http.rb"
+}
+
+@test "Check a basic site, ok" {
+  run $CHECK -h localhost -p /okay
+  [ $status = 0 ]
+  [ "$output" = "CheckHttp OK: 200, 0 bytes" ]
+}
+
+@test "Check a basic site, critical 404" {
+  run $CHECK -h localhost -p /notthere
+  [ $status = 2 ]
+  [ "$output" = "CheckHttp CRITICAL: 404" ]
+}
+
+@test "Check a basic site, critical 500" {
+  run $CHECK -h localhost -p /ohno
+  [ $status = 2 ]
+  [ "$output" = "CheckHttp CRITICAL: 500" ]
+}
+
+@test "Check a redirect site, ok" {
+  run $CHECK -h localhost -p /gooverthere -r
+  [ $status = 0 ]
+  [ "$output" = "CheckHttp OK: 301, 193 bytes" ]
+}
+
+@test "Check a redirect site, warning" {
+  run $CHECK -h localhost -p /gooverthere
+  [ $status = 1 ]
+  [ "$output" = "CheckHttp WARNING: 301" ]
+}
+
+@test "Check a site with a POST request, ok" {
+  run $CHECK -h localhost -p /postthingshere -m POST -b somejunk
+  [ $status = 0 ]
+  [ "$output" = "CheckHttp OK: 200, 0 bytes" ]
+}
+
+@test "Check a site with a POST request, critical" {
+  run $CHECK -h localhost -p /okay -m POST -b somejunk
+  [ $status = 2 ]
+}


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**

N/A

#### General

- [X] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [X] Update README with any necessary configuration snippets

- [X] Binstubs are created if needed

- [X] RuboCop passes

- [X] Existing tests pass 

#### New Plugins

- [X] Tests

- [X] Add the plugin to the README

- [X] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

We'd been using a customized fork of an old version of check-http.rb and are switching back to the community version. In doing that, we discovered two items that only our version could handle:

* Headers that are separated by a comma+space (e.g. `-H 'Header1: test1, Header2: test2'`) instead of just a comma. The space was not being stripped off in this version.
* Support for sending POST requests with a specified body string in addition to simple GETs.

This PR would resolve both of those and add a minimal set of integration tests for check-http.rb.

#### Known Compatablity Issues

N/A