### PR TITLE
fix default port selection for https

### DIFF
--- a/bin/check-http.rb
+++ b/bin/check-http.rb
@@ -67,8 +67,7 @@ class CheckHttp < Sensu::Plugin::Check::CLI
          short: '-P PORT',
          long: '--port PORT',
          proc: proc(&:to_i),
-         description: 'Select another port',
-         default: 80
+         description: 'Select another port'
 
   option :request_uri,
          short: '-p PATH',


### PR DESCRIPTION
remove default port setting, so that the code further down:

   config[:port] ||= config[:ssl] ? 443 : 80

can set an appropriate default based of the ssl setting.