### PR TITLE
Don't send basic auth when no password is supplied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Fixed
+- Don't send basic auth when no password is supplied
 
 ## [0.4.0] - 2016-04-26
 ### Changed

--- a/bin/check-http-cors.rb
+++ b/bin/check-http-cors.rb
@@ -127,7 +127,7 @@ class CheckCORS < Sensu::Plugin::Check::CLI
     end
 
     req = Net::HTTP::Get.new([config[:path], config[:query]].compact.join('?'))
-    unless config[:user].nil? && !config[:password].nil?
+    unless config[:user].nil? && config[:password].nil?
       req.basic_auth config[:user], config[:password]
     end
 

--- a/bin/check-http-json.rb
+++ b/bin/check-http-json.rb
@@ -113,7 +113,7 @@ class CheckJson < Sensu::Plugin::Check::CLI
       post_body = IO.readlines(config[:postbody])
       req.body = post_body.join
     end
-    unless config[:user].nil? && !config[:password].nil?
+    unless config[:user].nil? && config[:password].nil?
       req.basic_auth config[:user], config[:password]
     end
     if config[:header]

--- a/bin/check-http.rb
+++ b/bin/check-http.rb
@@ -262,7 +262,7 @@ class CheckHttp < Sensu::Plugin::Check::CLI
             Net::HTTP::Post.new(config[:request_uri], 'User-Agent' => config[:ua])
           end
 
-    unless config[:user].nil? && !config[:password].nil?
+    unless config[:user].nil? && config[:password].nil?
       req.basic_auth config[:user], config[:password]
     end
     if config[:header]


### PR DESCRIPTION
Currently, if no password is supplied (no -a option is passed), the check will
try to send basic auth credentials with a blank password. In addition, if a
password actually is supplied, then basic auth credentials won't be sent. This
change fixes the logic to be what is expected.