### PR TITLE
Simple support for negative regex matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ## [Unreleased]
 ### Fixed
 - Don't send basic auth when no password is supplied
+  Add `--negquery` to `check-http.rb` for query text that should not exist
 
 ## [0.4.0] - 2016-04-26
 ### Changed

--- a/bin/check-http.rb
+++ b/bin/check-http.rb
@@ -132,7 +132,12 @@ class CheckHttp < Sensu::Plugin::Check::CLI
   option :pattern,
          short: '-q PAT',
          long: '--query PAT',
-         description: 'Query for a specific pattern'
+         description: 'Query for a specific pattern that must exist'
+
+  option :negpattern,
+         short: '-n PAT',
+         long: '--negquery PAT',
+         description: 'Query for a specific pattern that must be absent'
 
   option :timeout,
          short: '-t SECS',
@@ -308,6 +313,12 @@ class CheckHttp < Sensu::Plugin::Check::CLI
           ok "#{res.code}, found /#{config[:pattern]}/ in #{size} bytes" + body
         else
           critical "#{res.code}, did not find /#{config[:pattern]}/ in #{size} bytes: #{res.body[0...200]}..."
+        end
+      elsif config[:negpattern]
+        if res.body =~ /#{config[:pattern]}/
+          critical "#{res.code}, found /#{config[:pattern]}/ in #{size} bytes: #{res.body[0...200]}..."
+        else
+          ok "#{res.code}, did not find /#{config[:pattern]}/ in #{size} bytes" + body
         end
       else
         ok("#{res.code}, #{size} bytes" + body) unless config[:response_code]

--- a/bin/check-http.rb
+++ b/bin/check-http.rb
@@ -315,10 +315,10 @@ class CheckHttp < Sensu::Plugin::Check::CLI
           critical "#{res.code}, did not find /#{config[:pattern]}/ in #{size} bytes: #{res.body[0...200]}..."
         end
       elsif config[:negpattern]
-        if res.body =~ /#{config[:pattern]}/
-          critical "#{res.code}, found /#{config[:pattern]}/ in #{size} bytes: #{res.body[0...200]}..."
+        if res.body =~ /#{config[:negpattern]}/
+          critical "#{res.code}, found /#{config[:negpattern]}/ in #{size} bytes: #{res.body[0...200]}..."
         else
-          ok "#{res.code}, did not find /#{config[:pattern]}/ in #{size} bytes" + body
+          ok "#{res.code}, did not find /#{config[:negpattern]}/ in #{size} bytes" + body
         end
       else
         ok("#{res.code}, #{size} bytes" + body) unless config[:response_code]


### PR DESCRIPTION
I had a need to check for the absence of a regex in the HTTP body output, and I felt this was a much better way of doing it rather than unreadable negative lookaheads.
