### PR TITLE
check-https-cert default thresholds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ## [Unreleased]
 ### Fixed
 - Don't send basic auth when no password is supplied
+- Add default thresholds to check-https-cert.rb
 
 ## [0.4.0] - 2016-04-26
 ### Changed

--- a/bin/check-https-cert.rb
+++ b/bin/check-https-cert.rb
@@ -44,12 +44,14 @@ class CheckHttpCert < Sensu::Plugin::Check::CLI
          short: '-w',
          long: '--warning DAYS',
          proc: proc(&:to_i),
+         default: 50,
          description: 'Warn EXPIRE days before cert expires'
 
   option :critical,
          short: '-c',
          long: '--critical DAYS',
          proc: proc(&:to_i),
+         default: 25,
          description: 'Critical EXPIRE days before cert expires'
 
   option :insecure,


### PR DESCRIPTION
Adding threshold defaults to `check-https-cert.rb`. Currently there are no defaults, so when the check looks to compare against `config[:critical].to_i` it compares against 0. This means that in the case that a user omits the warning and critical flags (poor usage for sure, but alas: users) they will never get alerted to their SSL certs expiring.

Went with 50 days for warning and 25 for critical mostly as suggestions.