### PR TITLE
fix metrics-http-json when used without --object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ## [Unreleased]
 ### Changed
 - Reverting rest-client to 1.8 as 2.0 requires ruby >= 2.0
+- metrics-http-json: fix behavior when a root object key is not specified
 
 ## [1.0.0] - 2016-07-27
 ### Fixed

--- a/bin/metrics-http-json.rb
+++ b/bin/metrics-http-json.rb
@@ -82,10 +82,10 @@ class HttpJsonGraphite < Sensu::Plugin::Metric::CLI::Graphite
               output([scheme, metric].join('.'), v)
             end
           end
-          JSON.parse(r).each do |k, v|
-            if k == attribute
-              output([scheme, metric].join('.'), v)
-            end
+        end
+        JSON.parse(r).each do |k, v|
+          if k == attribute
+            output([scheme, metric].join('.'), v)
           end
         end
       end


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?** It is not.
#### General
- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)
- [X] Update README with any necessary configuration snippets
- [X] Binstubs are created if needed
- [x] RuboCop passes (well, it doesn't pass on master. None of the offenses are related to my changes though. Would be nice if this passed on master :)
- [x] Existing tests pass (Travis build is failing on master so they aren't going to pass here :)
#### Purpose

Presently, both blocks are inside the unless, and so if you don't specify an object, it never grabs any metrics. This maintains the original behavior of doing both scans/outputs if you _do_ specify an object, but if that is also a bug, then this should be an if/else.
#### Known Compatablity Issues
