### PR TITLE
Get the CI tests working again

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -8,7 +8,7 @@ provisioner:
   script: test/fixtures/bootstrap.sh
 
 verifier:
-  ruby_bindir: /opt/sensu/embedded/bin
+  ruby_bindir: <%= ENV['MY_RUBY_HOME'] || '/opt/sensu/embedded' %>/bin
 
 platforms:
   - name: ubuntu-14.04

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ rvm:
 - 2.0
 - 2.1
 - 2.2
-- 2.3.0
+- 2.3
 notifications:
   email:
     recipients:
@@ -17,8 +17,12 @@ notifications:
     on_success: change
     on_failure: always
 script:
+  - rvm use --default $TRAVIS_RUB_VERSION
+  - echo 'export PATH="$PATH:/home/travis/.rvm/bin"' | sudo tee -a /etc/profile
+  - echo 'source /home/travis/.rvm/scripts/rvm' | sudo tee -a /etc/profile
   - bundle exec rake default
   - bundle exec kitchen test
+  - sudo chown -R travis:travis /home/travis/.rvm
   - gem build sensu-plugins-http.gemspec
   - gem install sensu-plugins-http-*.gem
 deploy:
@@ -32,8 +36,9 @@ deploy:
     rvm: 2.0
     rvm: 2.1
     rvm: 2.2
-    rvm: 2.3.0
+    rvm: 2.3
     repo: sensu-plugins/sensu-plugins-http
 
 env:
-  - KITCHEN_LOCAL_YAML=.kitchen.travis.yml
+  global:
+    - KITCHEN_LOCAL_YAML=.kitchen.travis.yml

--- a/sensu-plugins-http.gemspec
+++ b/sensu-plugins-http.gemspec
@@ -46,6 +46,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'test-kitchen',              '~> 1.6'
   s.add_development_dependency 'kitchen-vagrant',           '~> 0.19'
   s.add_development_dependency 'kitchen-localhost',         '~> 0.3'
-  s.add_development_dependency 'net-ssh',                   '~> 2.9'
   s.add_development_dependency 'json',                      '< 2.0.0'
 end

--- a/test/fixtures/bootstrap.sh
+++ b/test/fixtures/bootstrap.sh
@@ -1,61 +1,66 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Set up a super simple web server and make it accept GET and POST requests
 # for Sensu plugin testing.
 #
 
+set -e
+
+source /etc/profile
 DATA_DIR=/tmp/kitchen/data
-SENSU_DIR=/opt/sensu
-GEM=$SENSU_DIR/embedded/bin/gem
-RUBY=$SENSU_DIR/embedded/bin/ruby
+RUBY_HOME=${MY_RUBY_HOME:-/opt/sensu/embedded}
 
-if [ ! -d $SENSU_DIR ]; then
-  wget -q http://repositories.sensuapp.org/apt/pubkey.gpg -O- | sudo apt-key add -
-  echo "deb http://repositories.sensuapp.org/apt sensu main" | sudo tee /etc/apt/sources.list.d/sensu.list
-  sudo apt-get update
-  sudo apt-get install -y git vim nginx sensu
-  sudo service nginx status || sudo service nginx start
-  sudo rm /etc/nginx/sites-enabled/default
-  echo "
-    server {
-      listen 80;
-    
-      location /okay {
-        limit_except GET {
-          deny all;
-        }
-        return 200;
-      }
-    
-      location /notthere {
-        limit_except GET {
-          deny all;
-        }
-        return 404;
-      }
-    
-      location /ohno {
-        limit_except GET {
-          deny all;
-        }
-        return 500;
-      }
-
-      location /gooverthere {
-         limit_except GET {
-           deny all;
-         }
-         return 301;
-      }
-    
-      location /postthingshere {
-        return 200;
-      }
-    }
-  " | sudo tee /etc/nginx/sites-enabled/sensu-plugins-http.conf
-  sudo service nginx restart
+if [ "$RUBY_HOME" = "/opt/sensu/embedded" ] && [ ! -d $RUBY_HOME ]; then
+  wget -q http://repositories.sensuapp.org/apt/pubkey.gpg -O- | apt-key add -
+  echo "deb http://repositories.sensuapp.org/apt sensu main" > /etc/apt/sources.list.d/sensu.list
+  apt-get update
+  apt-get install -y sensu
+else
+  apt-get update
 fi
 
+apt-get install -y nginx build-essential
+service nginx status || service nginx start
+rm /etc/nginx/sites-enabled/default
+echo "
+  server {
+    listen 80;
+
+    location /okay {
+      limit_except GET {
+        deny all;
+      }
+      return 200;
+    }
+
+    location /notthere {
+      limit_except GET {
+        deny all;
+      }
+      return 404;
+    }
+
+    location /ohno {
+      limit_except GET {
+        deny all;
+      }
+      return 500;
+    }
+
+    location /gooverthere {
+       limit_except GET {
+         deny all;
+       }
+       return 301;
+    }
+
+    location /postthingshere {
+      return 200;
+    }
+  }
+" > /etc/nginx/sites-enabled/sensu-plugins-http.conf
+service nginx restart
+
 cd $DATA_DIR
-SIGN_GEM=false $GEM build sensu-plugins-http.gemspec
-sudo sensu-install -p sensu-plugins-http-*.gem
+SIGN_GEM=false $RUBY_HOME/bin/gem build sensu-plugins-http.gemspec
+$RUBY_HOME/bin/gem install sensu-plugins-http-*.gem

--- a/test/integration/default/bats/check-http.bats
+++ b/test/integration/default/bats/check-http.bats
@@ -1,7 +1,24 @@
 #!/usr/bin/env bats
 
 setup() {
-  export CHECK="sudo -u sensu /opt/sensu/embedded/bin/check-http.rb"
+  export OLD_RUBY_HOME=$RUBY_HOME
+  export OLD_GEM_HOME=$GEM_HOME
+  export OLD_GEM_PATH=$GEM_PATH
+
+  unset GEM_HOME
+  unset GEM_PATH
+  source /etc/profile
+  export RUBY_HOME=${MY_RUBY_HOME:-/opt/sensu/embedded}
+
+  INNER_GEM_HOME=$($RUBY_HOME/bin/ruby -e 'print ENV["GEM_HOME"]')
+  [ -n "$INNER_GEM_HOME" ] && GEM_BIN=$INNER_GEM_HOME/bin || GEM_BIN=$RUBY_HOME/bin
+  export CHECK="$RUBY_HOME/bin/ruby $GEM_BIN/check-http.rb"
+}
+
+teardown() {
+  export RUBY_HOME=$OLD_RUBY_HOME
+  export GEM_HOME=$OLD_GEM_HOME
+  export GEM_PATH=$OLD_GEM_PATH
 }
 
 @test "Check a basic site, ok" {


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**

I'm not sure who introduced what change, but the test failures were
because Sensu's embedded Ruby environment and RVM in TravisCI were
stomping on each other's environment variables.

After doing a bunch of test runs in Travis, this seems to be enough to
get them going again. And has the added benefit of using RVM's Ruby for
the tests, so they cover all the versions of Ruby being tested against.

#### General

~Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)~
~Update README with any necessary configuration snippets~
~Binstubs are created if needed~
- [x] RuboCop passes
- [x] Existing tests pass 

#### New Plugins

~Tests~
~Add the plugin to the README~
~Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)~

#### Purpose

Get the CI build going again.

#### Known Compatablity Issues

N/A