### PR TITLE
Support looking for null values for keys in check-http-json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased]
 
+### Changed
+- check-http-json: fix incorrect "key not found" error when key value is null
+
 ## [2.0.0] - 2017-02-20
 ### Breaking Changes
 - Support for Ruby < 2.1 removed. Ruby 2.0 and older are EOL.

--- a/bin/check-http-json.rb
+++ b/bin/check-http-json.rb
@@ -92,7 +92,7 @@ class CheckJson < Sensu::Plugin::Check::CLI
         arr_key = parent + '[' + index.to_s + ']'
 
         if arr_key == desired_key
-          return value
+          return value.nil? ? 'null' : value
         end
 
         if desired_key.include? arr_key
@@ -107,7 +107,7 @@ class CheckJson < Sensu::Plugin::Check::CLI
         hash_key = parent + key_prefix + key
 
         if hash_key == desired_key
-          return value
+          return value.nil? ? 'null' : value
         end
 
         if desired_key.include?(hash_key + '.') || desired_key.include?(hash_key + '[')

--- a/test/fixtures/bootstrap.sh
+++ b/test/fixtures/bootstrap.sh
@@ -57,6 +57,13 @@ echo "
     location /postthingshere {
       return 200;
     }
+
+    location /json/okay {
+      limit_except GET {
+        deny all;
+      }
+      return 200 '{\"errors\":null}';
+    }
   }
 " > /etc/nginx/sites-enabled/sensu-plugins-http.conf
 service nginx restart

--- a/test/integration/default/bats/check-http.bats
+++ b/test/integration/default/bats/check-http.bats
@@ -13,6 +13,7 @@ setup() {
   INNER_GEM_HOME=$($RUBY_HOME/bin/ruby -e 'print ENV["GEM_HOME"]')
   [ -n "$INNER_GEM_HOME" ] && GEM_BIN=$INNER_GEM_HOME/bin || GEM_BIN=$RUBY_HOME/bin
   export CHECK="$RUBY_HOME/bin/ruby $GEM_BIN/check-http.rb"
+  export CHECK_JSON="$RUBY_HOME/bin/ruby $GEM_BIN/check-http-json.rb"
 }
 
 teardown() {
@@ -60,4 +61,9 @@ teardown() {
 @test "Check a site with a POST request, critical" {
   run $CHECK -h localhost -p /okay -m POST -d somejunk
   [ $status = 2 ]
+}
+
+@test "Check a site returns JSON with an 'errors' key containing null" {
+  run $CHECK_JSON -h localhost -p /json/okay -K errors -v null
+  [ $status = 0 ]
 }


### PR DESCRIPTION
## Pull Request Checklist

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass 

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

When trying to use the check_http_json.rb plugin, I would like to return an object from the healthcheck that contains an array of errors, or null if there are no errors. E.g.

1. `{"errors": null}`
2.`{"errors": ["the first error", "the second error"]}` 

The issue I'm encountering is that the plugin tells me the key does not exist when the value is null:

`CheckJson CRITICAL: key check failed: could not find key: errors`

I think this line is responsible: https://github.com/sensu-plugins/sensu-plugins-http/blob/master/bin/check-http-json.rb#L174

This pull request adds a test that confirms the fix

#### Known Compatibility Issues

