### PR TITLE
metrics-http-json-deep.rb: fix key normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Fixed
+- `metrics-http-json-deep`: fix key normalization (@ushi-as)
 
 ## [2.0.1] - 2017-02-21
 ### Fixed

--- a/bin/metrics-http-json-deep.rb
+++ b/bin/metrics-http-json-deep.rb
@@ -79,7 +79,7 @@ class JsonDeepMetrics < Sensu::Plugin::Metric::CLI::Graphite
 
   def deep_value(hash, scheme = '')
     hash.each do |key, value|
-      ekey = key.tr(/ /, '_')
+      ekey = key.tr(' ', '_')
       if value.is_a?(Hash)
         deep_value(value, "#{scheme}.#{ekey}")
       else


### PR DESCRIPTION
```String#tr``` accepts two strings as arguments. Not a RegExp.

See: https://ruby-doc.org/core-2.3.3/String.html#method-i-tr

It raises: ```no implicit conversion of Regexp into String``` at the moment.

## Pull Request Checklist

#### General

- [ ] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass 

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

#### Known Compatablity Issues

