### PR TITLE
Added 1s to acquire_resource timeout.

### DIFF
--- a/bin/check-http.rb
+++ b/bin/check-http.rb
@@ -206,7 +206,7 @@ class CheckHttp < Sensu::Plugin::Check::CLI
     end
 
     begin
-      Timeout.timeout(config[:timeout]) do
+      Timeout.timeout(config[:timeout] + 1) do
         acquire_resource
       end
     rescue Timeout::Error


### PR DESCRIPTION
This prevents trace from being output when http check times out, returning the correct error.

## Pull Request Checklist

This corrects issue #37 

#### General

- [ ] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass 

#### Purpose

This is to correct the trace output presented when a http request times out, allowing the human readable error to be presented.

#### Known Compatablity Issues

Unknown.
