### PR TITLE
check-http-json.rb options for numeric thresholds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Added
+- `check-http-json`: add --value-greater-than and --value-less-than options (@dave-handy)
+
 ## [2.1.0]
 ### Fixed
 - `check-http-json`: fix error when check fails and --whole-response is enabled (@ushis)

--- a/bin/check-http-json.rb
+++ b/bin/check-http-json.rb
@@ -5,7 +5,8 @@
 # DESCRIPTION:
 #   Takes either a URL or a combination of host/path/query/port/ssl, and checks
 #   for valid JSON output in the response. Can also optionally validate simple
-#   string key/value pairs, and check if a specified value is within bounds.
+#   string key/value pairs, and optionally check if a specified value is within
+#   bounds.
 #
 # OUTPUT:
 #   plain text
@@ -18,7 +19,12 @@
 #   gem: json
 #
 # USAGE:
-#   #YELLOW
+#   Check that will verify http status and JSON validity
+#      ./check-http-json.rb -u http://my.site.com/health.json
+#
+#   Check that will verify http status, JSON validity, and that page.totalElements value is
+#   greater than 10
+#      ./check-http-json.rb -u http://my.site.com/metric.json --key page.totalElements --value-greater-than 10
 #
 # NOTES:
 #   Based on Check HTTP by Sonian Inc.

--- a/test/fixtures/bootstrap.sh
+++ b/test/fixtures/bootstrap.sh
@@ -64,6 +64,13 @@ echo "
       }
       return 200 '{\"errors\":null}';
     }
+
+    location /json/metric {
+      limit_except GET {
+        deny all;
+      }
+      return 200 '{\"count\":5}';
+    }
   }
 " > /etc/nginx/sites-enabled/sensu-plugins-http.conf
 service nginx restart

--- a/test/integration/default/bats/check-http.bats
+++ b/test/integration/default/bats/check-http.bats
@@ -67,3 +67,8 @@ teardown() {
   run $CHECK_JSON -h localhost -p /json/okay -K errors -v null
   [ $status = 0 ]
 }
+
+@test "Check a site returns JSON with an 'failures' key between 4 and 6" {
+  run $CHECK_JSON -h localhost -p /json/metric -K count --value-greater-than 4 --value-less-than 6
+  [ $status = 0 ]
+}


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**
Nope

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [ ] Existing tests pass 

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose
I needed some minor improvements on the value checking functionality so I thought I would contribute them back. This is a simple extension of the --key and --value options. I've tested these locally and added the unit tests. Honestly I'm not sure how to run the unit tests...

#### Known Compatablity Issues
The success message format used when using `--key` and `--value` options was changed, so that the comparison operator success messages are a bit easier to interpret.
