### PR TITLE
add some requested examples for check-http.rb and added PUT method support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
-#Change Log
+# Change Log
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Added
+- check-http.rb: support PUT requests (@majormoses)
+- check-http.rb: added examples per GH issues (@majormoses)
 ## [2.2.0] - 2017-05-31
 ### Added
 - `check-http-json`: add --value-greater-than and --value-less-than options (@dave-handy)

--- a/bin/check-http.rb
+++ b/bin/check-http.rb
@@ -28,6 +28,11 @@
 #   Use a proxy to check a URL
 #   check-http.rb -u https://www.google.com --proxy-url http://my.proxy.com:3128
 #
+#   Check something with needing to set multiple headers
+#   check-http.rb -u https://www.google.com --header 'Origin: ma.local.box, SomeRandomHeader: foo'
+#
+#   Check something that requires a POST with json data
+#   check-http.rb -u https://httpbin.org/post --method POST --header 'Content-type: application/json' --body '{"foo": "bar"}'
 # NOTES:
 #
 # LICENSE:
@@ -77,9 +82,9 @@ class CheckHttp < Sensu::Plugin::Check::CLI
 
   option :method,
          short: '-m GET|POST',
-         long: '--method GET|POST',
-         description: 'Specify a GET or POST operation; defaults to GET',
-         in: %w(GET POST),
+         long: '--method GET|POST|PUT',
+         description: 'Specify a GET, POST, or PUT operation; defaults to GET',
+         in: %w(GET POST PUT),
          default: 'GET'
 
   option :header,
@@ -271,6 +276,8 @@ class CheckHttp < Sensu::Plugin::Check::CLI
             Net::HTTP::Get.new(config[:request_uri], 'User-Agent' => config[:ua])
           when 'POST'
             Net::HTTP::Post.new(config[:request_uri], 'User-Agent' => config[:ua])
+          when 'PUT'
+            Net::HTTP::Put.new(config[:request_uri], 'User-Agent' => config[:ua])
           end
 
     unless config[:user].nil? && config[:password].nil?


### PR DESCRIPTION
relates #31

Adds support for PUT method

## Pull Request Checklist

#74 , #22, #33, #31 

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass 


#### Purpose
Originally it was to add examples but after inspecting the code I also decided that we could easily support PUT requests as well so I added it.


#### Known Compatibility Issues

None