### PR TITLE
Add new options to dump json on failure and enable formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Added - 2018-02-08
+- Add new options `--dump-json` to dump json response on failure when enable. default: false (@jplindquist)
+- Add new `--pretty` option for pretty format json response when `--dump-json` is enabled. default: false (@jplindquist)
 
 ## [2.6.0] - 2017-07-31
 ### Added

--- a/sensu-plugins-http.gemspec
+++ b/sensu-plugins-http.gemspec
@@ -37,15 +37,17 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'bundler',                   '~> 1.7'
   s.add_development_dependency 'codeclimate-test-reporter', '~> 0.4'
   s.add_development_dependency 'github-markup',             '~> 1.3'
+  # locked to keep ruby 2.1 support, this is pulled in by test-kitchen
+  s.add_development_dependency 'mixlib-shellout',           ['< 2.3.0', '~> 2.2']
   s.add_development_dependency 'pry',                       '~> 0.10'
   s.add_development_dependency 'rake',                      '~> 10.0'
   s.add_development_dependency 'redcarpet',                 '~> 3.2'
   s.add_development_dependency 'rspec',                     '~> 3.1'
   s.add_development_dependency 'rubocop',                   '~> 0.40.0'
   s.add_development_dependency 'yard',                      '~> 0.8'
-  s.add_development_dependency 'test-kitchen',              '~> 1.6'
+  # intentionally locked as 1.17 requires ruby 2.3+
+  s.add_development_dependency 'test-kitchen',              '~> 1.16.0'
   s.add_development_dependency 'kitchen-vagrant',           '~> 0.19'
   s.add_development_dependency 'kitchen-localhost',         '~> 0.3'
-  s.add_development_dependency 'mixlib-shellout',           '~> 2.2.7'
   s.add_development_dependency 'json',                      '< 2.0.0'
 end


### PR DESCRIPTION
Add 2 new options `check-http-json.rb`:

- `--dump-json`, which defaults to *false* will dump the json response on failure
 and formatting

- `--pretty`, which defaults to *false* will format the json output in a pretty format if `--dump-json` is enabled

## Pull Request Checklist

**Is this in reference to an existing issue?**  Possibly?  Not sure if this relates to #85 or not honestly

#### General

- [X] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose
Allow users to include the json response in the result on failure, and format it if they so choose

#### Known Compatibility Issues
None, existing functionality remains exactly the same, just adding 2 new options