### PR TITLE
Use username and password in proxy url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased]
 
+### Added
+- `check-http`: Added ability to use username and password in proxy url (@mclarkson)
+
 ## [2.6.0] - 2017-07-31
 ### Added
 - ruby 2.4 testing (@majormoses)

--- a/bin/check-http.rb
+++ b/bin/check-http.rb
@@ -28,6 +28,10 @@
 #   Use a proxy to check a URL
 #   check-http.rb -u https://www.google.com --proxy-url http://my.proxy.com:3128
 #
+#   Use a proxy with username and password to check a URL
+#   NOTE: Use 'check token substition' to avoid credentials leakage!
+#   check-http.rb -u https://www.google.com --proxy-url http://a_user:a_pass@my.proxy.com:3128
+#
 #   Check something with needing to set multiple headers
 #   check-http.rb -u https://www.google.com --header 'Origin: ma.local.box, SomeRandomHeader: foo'
 #
@@ -40,6 +44,7 @@
 #   Updated by Lewis Preson 2012 to accept basic auth credentials
 #   Updated by SweetSpot 2012 to require specified redirect
 #   Updated by Chris Armstrong 2013 to accept multiple headers
+#   Updated by Mark Clarkson 2018 to accept proxy auth credentials
 #   Released under the same terms as Sensu (the MIT license); see LICENSE
 #   for details.
 #
@@ -255,7 +260,11 @@ class CheckHttp < Sensu::Plugin::Check::CLI
       if proxy_uri.host.nil?
         unknown 'Invalid proxy url specified'
       end
-      http = Net::HTTP.new(config[:host], config[:port], proxy_uri.host, proxy_uri.port)
+      http = if proxy_uri.user && proxy_uri.password
+               Net::HTTP.new(config[:host], config[:port], proxy_uri.host, proxy_uri.port, proxy_uri.user, proxy_uri.password)
+             else
+               Net::HTTP.new(config[:host], config[:port], proxy_uri.host, proxy_uri.port)
+             end
     else
       http = Net::HTTP.new(config[:host], config[:port])
     end


### PR DESCRIPTION
## Pull Request Checklist

No existing issue

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

Allow username and password in proxy url:
```
... --proxy-url http://a_user:a_pass@localhost:3128 ...
```

#### Known Compatibility Issues
