### PR TITLE
Fix metrics curl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+### Fixed
+- `metrics-curl.rb`: fix shell quoting problem at execution and parse correctly curl metrics on non-C locale. (@multani)
 
 ## [2.8.2] - 2018-03-13
 ### Fixed

--- a/bin/metrics-curl.rb
+++ b/bin/metrics-curl.rb
@@ -58,7 +58,7 @@ class CurlMetrics < Sensu::Plugin::Metric::CLI::Graphite
          default: "#{Socket.gethostname}.curl_timings"
 
   def run
-    cmd = "curl --silent --output /dev/null #{config[:curl_args]} "
+    cmd = "LC_NUMERIC=C curl --silent --output /dev/null #{config[:curl_args]} "
     cmd += '-w "%{time_total},%{time_namelookup},%{time_connect},%{time_pretransfer},%{time_redirect},%{time_starttransfer},%{http_code}" '
     cmd += config[:url]
 

--- a/bin/metrics-curl.rb
+++ b/bin/metrics-curl.rb
@@ -59,7 +59,7 @@ class CurlMetrics < Sensu::Plugin::Metric::CLI::Graphite
 
   def run
     cmd = "curl --silent --output /dev/null #{config[:curl_args]} "
-    cmd += '-w %{time_total},%{time_namelookup},%{time_connect},%{time_pretransfer},%{time_redirect},%{time_starttransfer},%{http_code}" '
+    cmd += '-w "%{time_total},%{time_namelookup},%{time_connect},%{time_pretransfer},%{time_redirect},%{time_starttransfer},%{http_code}" '
     cmd += config[:url]
 
     output = `#{cmd}`


### PR DESCRIPTION
## Pull Request Checklist

Fixes #54

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass

#### Purpose

The script wasn't working before:

```
$ bundle exec bin/metrics-curl.rb -s test -u https://www.google.com
sh: 1: Syntax error: Unterminated quoted string
test.time_total
test.time_namelookup
test.time_connect
test.time_pretransfer
test.time_redirect
test.time_starttransfer
test.http_code
```

The first commit fixes the syntax error, but numbers are still off (especially visible for the ``http_code`` output):

```
$ bundle exec bin/metrics-curl.rb -s test -u https://www.google.com
test.time_total 0 1521033690
test.time_namelookup 165517 1521033690
test.time_connect 0 1521033690
test.time_pretransfer 028433 1521033690
test.time_redirect 0 1521033690
test.time_starttransfer 052873 1521033690
test.http_code 0 1521033690
```

But I'm using the French locale here:
```
$ locale
LANG=en_US.utf8
LANGUAGE=
LC_CTYPE="en_US.utf8"
LC_NUMERIC=fr_FR.UTF-8
LC_TIME=fr_FR.UTF-8
LC_COLLATE="en_US.utf8"
LC_MONETARY=fr_FR.UTF-8
LC_MESSAGES="en_US.utf8"
LC_PAPER=fr_FR.UTF-8
LC_NAME="en_US.utf8"
LC_ADDRESS="en_US.utf8"
LC_TELEPHONE="en_US.utf8"
LC_MEASUREMENT=fr_FR.UTF-8
LC_IDENTIFICATION="en_US.utf8"
LC_ALL=
$ LC_NUMERIC=C bundle exec bin/metrics-curl.rb -s test -u https://www.google.com
test.time_total 0.132413 1521033715
test.time_namelookup 0.004269 1521033715
test.time_connect 0.028579 1521033715
test.time_pretransfer 0.100833 1521033715
test.time_redirect 0.000000 1521033715
test.time_starttransfer 0.131823 1521033715
test.http_code 302 1521033715
```

Second commit fixes this for good:

```
$ bundle exec bin/metrics-curl.rb -s test -u https://www.google.com             
test.time_total 0.138064 1521033777
test.time_namelookup 0.004124 1521033777
test.time_connect 0.028628 1521033777
test.time_pretransfer 0.111635 1521033777
test.time_redirect 0.000000 1521033777
test.time_starttransfer 0.137108 1521033777
test.http_code 302 1521033777
```

@majormoses I'll be happy to try to write an integration test for that but ``bundle exec rake default`` fails (``cannot load such file -- spec_helper``).

#### Known Compatibility Issues

None