### PR TITLE
Add --post-body option to check-http-json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins
 
 ## [Unreleased]
 
+### Added
+- `check-http-json.rb`: add option `--post-body` to include a post body (@andy-s-clark)
+
 ## [2.8.4] - 2018-03-27
 ### Security
 - updated yard dependency to `~> 0.9.11` per: https://nvd.nist.gov/vuln/detail/CVE-2017-17042 (@majormoses)

--- a/bin/check-http-json.rb
+++ b/bin/check-http-json.rb
@@ -28,6 +28,9 @@
 #   greater than 10
 #      ./check-http-json.rb -u http://my.site.com/metric.json --key page.totalElements --value-greater-than 10
 #
+#   Check that will POST json
+#      ./check-http-json.rb -u http://my.site.com/metric.json -m POST --header 'Content-type: application/json' --post-body '{"serverId": "myserver"}'
+#
 # NOTES:
 #   Based on Check HTTP by Sonian Inc.
 #
@@ -53,6 +56,7 @@ class CheckJson < Sensu::Plugin::Check::CLI
   option :port, short: '-P PORT', proc: proc(&:to_i)
   option :method, short: '-m GET|POST'
   option :postbody, short: '-b /file/with/post/body'
+  option :post_body, long: '--post-body VALUE'
   option :header, short: '-H HEADER', long: '--header HEADER'
   option :ssl, short: '-s', boolean: true, default: false
   option :insecure, short: '-k', boolean: true, default: false
@@ -163,6 +167,9 @@ class CheckJson < Sensu::Plugin::Check::CLI
     if config[:postbody]
       post_body = IO.readlines(config[:postbody])
       req.body = post_body.join
+    end
+    if config[:post_body]
+      req.body = config[:post_body]
     end
     unless config[:user].nil? && config[:password].nil?
       req.basic_auth config[:user], config[:password]


### PR DESCRIPTION
## Pull Request Checklist

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass

#### Purpose
* Allows including the body of a POST as an argument
* Leaves existing `--postbody`, that grabs the body from a file, as-is for
 backward compatibility.

#### Known Compatibility Issues
