### PR TITLE
check-http: accept multiple http status codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+### Added
+- `check-http.rb`: add ability to specify a comma-separated list of accepted status codes for `--response-code` option (@psviderski)
 
 ## [2.10.0] - 2018-05-23
 ### Added


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**
https://github.com/sensu-plugins/sensu-plugins-http/issues/89

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [X] Update README with any necessary configuration snippets

- [X] Binstubs are created if needed

- [X] RuboCop passes

- [x] Existing tests pass

#### Purpose
Allow `--response-code` option to accept not only a single HTTP status code but also a comma-separated list of codes. In the later case expect a response with status code equal to any one from the list.

#### Known Compatibility Issues