### PR TITLE
Add regex support to --response-code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins
 ## [Unreleased]
 ### Added
 - `check-http-json.rb`: add option `--response-code` for checking the HTTP response code
+- `check-http.rb`: modify option `--response-code` to accept a regex
 
 ## [2.10.0] - 2018-05-23
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+### Added
+- `check-http-json.rb`: add option `--response-code` for checking the HTTP response code
 
 ## [2.10.0] - 2018-05-23
 ### Added

--- a/bin/check-http-json.rb
+++ b/bin/check-http-json.rb
@@ -76,8 +76,8 @@ class CheckJson < Sensu::Plugin::Check::CLI
 
   option :response_code,
          long: '--response-code REGEX',
-         description: "Check for a specific response code REGEX",
-         default: '^2'
+         description: 'Critical if HTTP response code does not match REGEX',
+         default: '^2([0-9]{2})$'
 
   def run
     if config[:url]

--- a/bin/check-http-json.rb
+++ b/bin/check-http-json.rb
@@ -74,6 +74,11 @@ class CheckJson < Sensu::Plugin::Check::CLI
   option :dump_json, short: '-d', long: '--dump-json', boolean: true, default: false
   option :pretty, long: '--pretty', boolean: true, default: false
 
+  option :response_code,
+         long: '--response-code REGEX',
+         description: "Check for a specific response code REGEX",
+         default: '^2'
+
   def run
     if config[:url]
       uri = URI.parse(config[:url])
@@ -182,7 +187,7 @@ class CheckJson < Sensu::Plugin::Check::CLI
     end
     res = http.request(req)
 
-    unless res.code =~ /^2/
+    if res.code !~ /#{config[:response_code]}/
       critical "http code: #{res.code}: body: #{res.body}" if config[:whole_response]
       critical res.code
     end

--- a/bin/check-http.rb
+++ b/bin/check-http.rb
@@ -205,8 +205,8 @@ class CheckHttp < Sensu::Plugin::Check::CLI
          proc: proc(&:to_i)
 
   option :response_code,
-         long: '--response-code CODE',
-         description: 'Check for a specific response code'
+         long: '--response-code REGEX',
+         description: 'Critical if HTTP response code does not match REGEX'
 
   option :proxy_url,
          long: '--proxy-url PROXY_URL',
@@ -408,7 +408,7 @@ class CheckHttp < Sensu::Plugin::Check::CLI
       warning(res.code + body) unless config[:response_code]
     end
 
-    if config[:response_code] && config[:response_code] == res.code
+    if config[:response_code] && res.code =~ /#{config[:response_code]}/
       ok "#{res.code}, #{size} bytes" + body
 
     else


### PR DESCRIPTION
## Pull Request Checklist

#### General

- [X] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [X] Update README with any necessary configuration snippets

- [X] Binstubs are created if needed

- [X] RuboCop passes

- [X] Existing tests pass

#### Purpose
Add regex support to --response-code in check-http
Add --response-code option to check-http-json

#### Known Compatibility Issues
