### PR TITLE
Remove use of Timeout.timeout() as it obscures DNS lookup errors. Cap…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ mkmf.log
 #Intellij files
 *.iml
 *.idea
+
+vendor/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+### Added
+- `check-http.rb`: Add options to set `--open-timeout` and `--read-timeout` for Net:HTTP. Additionally rescue `Net::OpenTimeout` and `Net::ReadTimeout` exception classes (@johanek)
+- `check-http.rb`: exposed `--dns-timeout` for Ruby DNS Resolver. (@johanek)
+
 ### Changed
-- `check-http.rb`: Add options to set open-timeout and read-timeout for Net:HTTP. Improve output on what Net::HTTP timeout was encountered.
-- `check-http.rb`: Use ruby DNS resolver, and set DNS resolution timeout.
+- `check-http.rb`: switched to using rubies DNS resolver to allow catching DNS failures when Net::HTTP establishes connection. (@johanek)
 
 ## [4.0.0] - 2018-12-17
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins
 ## [Unreleased]
 ### Changed
 - `check-http.rb`: Add options to set open-timeout and read-timeout for Net:HTTP. Improve output on what Net::HTTP timeout was encountered.
+- `check-http.rb`: Use ruby DNS resolver, and set DNS resolution timeout.
 
 ## [4.0.0] - 2018-12-17
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+### Changed
+- `check-http.rb`: Add options to set open-timeout and read-timeout for Net:HTTP. Improve output on what Net::HTTP timeout was encountered.
 
 ## [4.0.0] - 2018-12-17
 ### Breaking Changes

--- a/bin/check-http.rb
+++ b/bin/check-http.rb
@@ -59,6 +59,7 @@ require 'sensu-plugin/check/cli'
 require 'net/http'
 require 'net/https'
 require 'digest'
+require 'resolv-replace'
 
 #
 # Check HTTP
@@ -261,6 +262,11 @@ class CheckHttp < Sensu::Plugin::Check::CLI
       end
       config[:port] ||= config[:ssl] ? 443 : 80
     end
+
+    # Use Ruby DNS Resolver and set DNS resolution timeout to 800ms
+    dns_resolver = Resolv::DNS.new
+    dns_resolver.timeouts = 0.8
+    Resolv::DefaultResolver.replace_resolvers([dns_resolver])
 
     begin
       Timeout.timeout(config[:timeout]) do

--- a/test/integration/helpers/serverspec/check-http-shared_spec.rb
+++ b/test/integration/helpers/serverspec/check-http-shared_spec.rb
@@ -6,7 +6,7 @@ require 'shared_spec'
 gem_path = '/usr/local/bin'
 check_name = 'check-http.rb'
 check = "#{gem_path}/#{check_name}"
-domain = 'localhost'
+domain = '127.0.0.1'
 
 describe 'ruby environment' do
   it_behaves_like 'ruby checks', check
@@ -40,8 +40,14 @@ end
 describe command("#{check} --url https://#{domain}/okay") do
   its(:exit_status) { should eq 2 }
   if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.3.0')
-    its(:stdout) { should match(/CheckHttp CRITICAL: Request error: Failed to open TCP connection to localhost:443/) }
+    its(:stdout) { should match(/CheckHttp CRITICAL: Request error: Failed to open TCP connection to 127.0.0.1:443/) }
   else
-    its(:stdout) { should match(/CheckHttp CRITICAL: Request error: Cannot assign requested address - connect\(2\) for "localhost" port 443/) }
+    its(:stdout) { should match(/CheckHttp CRITICAL: Request error: Cannot assign requested address - connect\(2\) for "127.0.0.1" port 443/) }
   end
+end
+
+# DNS timeout
+describe command("#{check} --url http://blackhole.webpagetest.org/okay --dns-timeout 0.00001") do
+  its(:exit_status) { should eq 2 }
+  its(:stdout) { should match(/CheckHttp CRITICAL: Request error: Failed to open TCP connection to blackhole.webpagetest.org/) }
 end


### PR DESCRIPTION
…ture Net::HTTP errors

## Pull Request Checklist

Related to comments in #82 

#### General

- [ ] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

~- [ ] Update README with any necessary configuration snippets~

~- [ ] Binstubs are created if needed~

- [x] RuboCop passes

- [x] Existing tests pass

#### Purpose

Improve error reporting related to Net::HTTP timeouts