### PR TITLE
allow to specify --response-code for 3xx codes without specifying -r or --response-code option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+### Changed
+check-http.rb: Allow to specify `--response-code` for 3xx codes without having to specify `-r` or `--redirect-to` explicitly
 
 ## [5.1.0] - 2019-05-06
 ### Added

--- a/bin/check-http.rb
+++ b/bin/check-http.rb
@@ -428,7 +428,7 @@ class CheckHttp < Sensu::Plugin::Check::CLI
             critical "Expected redirect to #{config[:redirectto]} instead redirected to #{res['Location']}" + body
           end
         end
-      else
+      elsif !config[:response_code]
         warning res.code + body
       end
     when /^4/, /^5/


### PR DESCRIPTION
allow to specify `--response-code` for 3xx codes without specifying `-r` or `--redirect-to`

## Pull Request Checklist

#### General

- [ x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ x] RuboCop passes

- [x ] Existing tests pass

#### Purpose
Currently if you run `check-http.rb` with `--response-code` for a 3xx response code e.g. `301` and do not specify `-r` or `--redirect-to` the check raises a warning instead of the expected behaviour of passing the check. This PR will fix this by not returning a warning if a 3xx response code was returned by the server and `--response-code` is set.