### PR TITLE
Fixed A bug where after Sensu plugin v2.1.0 you can nolonger call require 'json' in a sensu-plugin.   You need to leverage require 'sensu/json' instead.  See -  https://github.com/sensu-plugins/sensu-plugin/issues/127

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+metrics-http-json.rb: Added the option to disable proxy
+metrics-http-json.rb: Fixed A bug where after Sensu plugin v2.1.0 you can nolonger call require 'json' in a sensu-plugin. You need to leverage require 'sensu/json' instead. See - https://github.com/sensu-plugins/sensu-plugin/issues/127
 metrics-http-json.rb: Added the option to disable ssl cert verification
 metrics-http-json.rb: Added debug option to see the processing of json data
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+metrics-http-json.rb: Added the option to disable ssl cert verification
+metrics-http-json.rb: Added debug option to see the processing of json data
 
 ## [5.0.0] - 2019-04-18
 ### Breaking Changes

--- a/bin/metrics-http-json.rb
+++ b/bin/metrics-http-json.rb
@@ -66,7 +66,7 @@ class HttpJsonGraphite < Sensu::Plugin::Metric::CLI::Graphite
          long: '--object OBJECT'
 
   option :insecure,
-         description: 'By default, every SSL connection made is verified to be secure. This option allows you to proceed and operate even for server connections otherwise considered insecure.',
+         description: 'By default, every SSL connection made is verified to be secure. This option allows you to disable the verification',
          short: '-k',
          long: '--insecure',
          boolean: true,
@@ -77,10 +77,9 @@ class HttpJsonGraphite < Sensu::Plugin::Metric::CLI::Graphite
          long: '--debug',
          default: false
 
-    
 
   def run
-    puts "args config: #{config.to_s}" if config[:debug]
+    puts "args config: #{config}" if config[:debug]
 
     scheme = config[:scheme].to_s
     metric_pair_input = config[:metric].to_s
@@ -91,13 +90,12 @@ class HttpJsonGraphite < Sensu::Plugin::Metric::CLI::Graphite
     url = URI.encode(config[:url].to_s) # rubocop:disable Lint/UriEscapeUnescape
     begin
       r = RestClient::Request.execute(
-            :url => url, 
-            :method => :get, 
-            #:headers => headers,
-            :verify_ssl => !config[:insecure]
-          )
+                                       url: url,
+                                       method: :get,
+                                       verify_ssl: !config[:insecure]
+                                     )
 
-      puts "Http response: #{r.to_s}" if config[:debug]
+      puts "Http response: #{r}" if config[:debug]
       metric_pair_array = metric_pair_input.split(/,/)
       metric_pair_array.each do |m|
         metric, attribute = m.to_s.split(/::/)

--- a/bin/metrics-http-json.rb
+++ b/bin/metrics-http-json.rb
@@ -89,10 +89,10 @@ class HttpJsonGraphite < Sensu::Plugin::Metric::CLI::Graphite
     url = URI.encode(config[:url].to_s) # rubocop:disable Lint/UriEscapeUnescape
     begin
       r = RestClient::Request.execute(
-                                      url: url,
-                                      method: :get,
-                                      verify_ssl: !config[:insecure]
-                                     )
+        url: url,
+        method: :get,
+        verify_ssl: !config[:insecure]
+      )
 
       puts "Http response: #{r}" if config[:debug]
       metric_pair_array = metric_pair_input.split(/,/)

--- a/bin/metrics-http-json.rb
+++ b/bin/metrics-http-json.rb
@@ -77,7 +77,6 @@ class HttpJsonGraphite < Sensu::Plugin::Metric::CLI::Graphite
          long: '--debug',
          default: false
 
-
   def run
     puts "args config: #{config}" if config[:debug]
 
@@ -90,9 +89,9 @@ class HttpJsonGraphite < Sensu::Plugin::Metric::CLI::Graphite
     url = URI.encode(config[:url].to_s) # rubocop:disable Lint/UriEscapeUnescape
     begin
       r = RestClient::Request.execute(
-                                       url: url,
-                                       method: :get,
-                                       verify_ssl: !config[:insecure]
+                                      url: url,
+                                      method: :get,
+                                      verify_ssl: !config[:insecure]
                                      )
 
       puts "Http response: #{r}" if config[:debug]

--- a/bin/metrics-http-json.rb
+++ b/bin/metrics-http-json.rb
@@ -65,7 +65,23 @@ class HttpJsonGraphite < Sensu::Plugin::Metric::CLI::Graphite
          short: '-o OBJECT',
          long: '--object OBJECT'
 
+  option :insecure,
+         description: 'By default, every SSL connection made is verified to be secure. This option allows you to proceed and operate even for server connections otherwise considered insecure.',
+         short: '-k',
+         long: '--insecure',
+         boolean: true,
+         default: false
+
+  option :debug,
+         short: '-d',
+         long: '--debug',
+         default: false
+
+    
+
   def run
+    puts "args config: #{config.to_s}" if config[:debug]
+
     scheme = config[:scheme].to_s
     metric_pair_input = config[:metric].to_s
     if config[:object]
@@ -74,10 +90,18 @@ class HttpJsonGraphite < Sensu::Plugin::Metric::CLI::Graphite
     # TODO: figure out what to do here
     url = URI.encode(config[:url].to_s) # rubocop:disable Lint/UriEscapeUnescape
     begin
-      r = RestClient.get url
+      r = RestClient::Request.execute(
+            :url => url, 
+            :method => :get, 
+            #:headers => headers,
+            :verify_ssl => !config[:insecure]
+          )
+
+      puts "Http response: #{r.to_s}" if config[:debug]
       metric_pair_array = metric_pair_input.split(/,/)
       metric_pair_array.each do |m|
         metric, attribute = m.to_s.split(/::/)
+        puts "metric: #{metric}, attribute: #{attribute}" if config[:debug]
         unless object.nil?
           JSON.parse(r)[object].each do |k, v|
             if k == attribute


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?** NO

#### General

- [ X] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

#### Known Compatibility Issues
