### PR TITLE
Handle empty body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins
 
 ## [Unreleased]
 
+### Fixed
+- `check-http.rb`: An empty response body when using `-w` no longer creates a potentially confusing `no implicit conversion of nil into String` error
+
 ## [5.1.1] - 2019-06-21
 ### Fixed
 - Fix issue with JSON.parse referencing sensu-plugin subclass instead of top level ::JSON module as intended

--- a/bin/check-http.rb
+++ b/bin/check-http.rb
@@ -363,7 +363,7 @@ class CheckHttp < Sensu::Plugin::Check::CLI
     res = http.request(req)
 
     body = if config[:whole_response]
-             "\n" + res.body
+             "\n" + res.body.to_s
            else
              body = if config[:response_bytes] # rubocop:disable Lint/UselessAssignment
                       "\n" + res.body[0..config[:response_bytes]]


### PR DESCRIPTION
to avoid `no implicit conversion of nil into String` errors when using -w

## Pull Request Checklist

There's no open issue that I can find for this, but it's fixing something that has confused people quite often in our check output.

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [x] RuboCop passes

- [x] Existing tests pass - `rake integration` passes, but I can't successfully run `rake spec` locally against master either - automated tests all passed on travis though

#### Purpose

to avoid `no implicit conversion of nil into String` errors when using -w and getting an empty body in the response, because this generally isn't a very helpful indication of what the actual problem is when a check starts failing and can get in the way of people investigating the real issue

#### Known Compatibility Issues
