### PR TITLE
Fix/rdoc dev dep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+### Changed
+- Make rdoc a development requirement for ruby installations that package rdoc as a gem instead of as part of base ruby
+
 
 ## [5.1.1] - 2019-06-21
 ### Fixed

--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,6 @@
 
 require 'bundler/gem_tasks'
 require 'github/markup'
-require 'kitchen/rake_tasks'
 require 'redcarpet'
 require 'rspec/core/rake_task'
 require 'rubocop/rake_task'
@@ -38,9 +37,14 @@ task :check_binstubs do
   end
 end
 
-Kitchen::RakeTasks.new
-desc 'Alias for kitchen:all'
-task integration: 'kitchen:all'
+begin
+  require 'kitchen/rake_tasks'
+  Kitchen::RakeTasks.new
+  desc 'Alias for kitchen:all'
+  task integration: 'kitchen:all'
+rescue Kitchen::UserError
+  puts 'Kitchen module not loading'
+end
 
 task default: %i[spec make_bin_executable yard rubocop check_binstubs integration]
 task quick: %i[make_bin_executable yard rubocop check_binstubs]

--- a/sensu-plugins-http.gemspec
+++ b/sensu-plugins-http.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
   s.add_runtime_dependency 'oj', '~> 2.18'
   s.add_runtime_dependency 'rest-client', '~> 2.0.2'
 
-  s.add_development_dependency 'bundler',                   '~> 1.7'
+  s.add_development_dependency 'bundler',                   '~> 2.1'
   s.add_development_dependency 'github-markup',             '~> 3.0'
   s.add_development_dependency 'json',                      '< 2.0.0'
   s.add_development_dependency 'kitchen-docker',            '~> 2.6'

--- a/sensu-plugins-http.gemspec
+++ b/sensu-plugins-http.gemspec
@@ -46,6 +46,7 @@ Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
   s.add_development_dependency 'kitchen-vagrant',           '~> 1.3'
   s.add_development_dependency 'pry',                       '~> 0.10'
   s.add_development_dependency 'rake',                      '~> 12.3'
+  s.add_development_dependency 'rdoc'
   s.add_development_dependency 'redcarpet',                 '~> 3.2'
   s.add_development_dependency 'rspec',                     '~> 3.1'
   s.add_development_dependency 'rubocop',                   '~> 0.51.0'


### PR DESCRIPTION
## Pull Request Checklist

Add rdoc as development dependency so that bundle install includes rdoc on development systems where rdoc is not part of base ruby install. (Fedora/Centos/RHEL) packages ruby rdoc as a gem.

Unversioned for now, until its clear we need to version it.
