### PR TITLE
add custom HTTP headers to metrics-http-json.rb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+### Added
+- `metrics-http-json.rb`: Added `-H/--header` flag to pass custom HTTP headers.
 
 
 ## [6.0.1] - 2020-01-30


### PR DESCRIPTION
Added -H/--header flag to pass custom HTTP headers in metrics-http-json.rb.
This makes it possible to use authentication token or any other function based on HTTP headers.

## Pull Request Checklist

**Is this in reference to an existing issue?**
#176

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)  

- [x] Update README with any necessary configuration snippets  
-> There was no entry about `metrics-http-json.rb` yet.

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass

#### Purpose

Currently it is not possible to pass custom HTTP headers to the request. This would be nice, because it would enable to use Authentication tokens or any other function based on HTTP headers.

#### Known Compatibility Issues
